### PR TITLE
Fix Cloudflare compatibility date for deployment

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel-prop",
-  "compatibility_date": "2025-08-05",
+  "compatibility_date": "2024-08-05",
   "assets": {
     "directory": "./out"
   }


### PR DESCRIPTION
## Summary
- update the Cloudflare Worker compatibility date to a current value so deployments no longer fail

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73d8a1d50832f979081050428b566