### PR TITLE
Fix mobile text wrapping and overflow issues

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -12,6 +12,20 @@
   body {
     @apply bg-slate-50 text-slate-900;
     font-feature-settings: 'rlig' 1, 'calt' 1;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    text-wrap: pretty;
+  }
+
+  :where(p, h1, h2, h3, h4, h5, h6, li, a, span, strong, em) {
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
+  *,
+  *::before,
+  *::after {
+    min-width: 0;
   }
 
   *:focus-visible {


### PR DESCRIPTION
## Summary
- ensure text elements wrap gracefully to prevent overlap on narrow viewports
- allow flex and grid children to shrink so long content no longer spills outside cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7fb066368832f8e925b3b824dc78e