### PR TITLE
Add GH_TOKEN support for GitHub API calls

### DIFF
--- a/lib/github-api.ts
+++ b/lib/github-api.ts
@@ -3,8 +3,21 @@ import type { Release, RateLimit, GitHubApiResponse, ApiError } from './types';
 const GITHUB_API_BASE = 'https://api.github.com';
 const REPO_OWNER = 'Elcapitanoe';
 const REPO_NAME = 'Komodo-Build-Prop';
-const REQUEST_TIMEOUT = 15000; 
-const MAX_RETRIES = 2; 
+const REQUEST_TIMEOUT = 15000;
+const MAX_RETRIES = 2;
+
+function resolveGitHubToken(): string | undefined {
+  if (typeof process !== 'undefined' && typeof process.env !== 'undefined' && process.env.GH_TOKEN) {
+    return process.env.GH_TOKEN;
+  }
+
+  try {
+    const env = (import.meta as ImportMeta | undefined)?.env;
+    return env?.GH_TOKEN ?? env?.VITE_GH_TOKEN ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 interface RequestOptions {
   readonly timeout?: number;
@@ -34,7 +47,7 @@ function createHeaders(etag?: string): HeadersInit {
     'X-GitHub-Api-Version': '2022-11-28',
   };
 
-  const token = process.env.GH_TOKEN;
+  const token = resolveGitHubToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,2 +1,11 @@
 // Global type declarations for build-time constants
 declare const __BUILD_TIME__: string;
+
+interface ImportMetaEnv {
+  readonly GH_TOKEN?: string;
+  readonly VITE_GH_TOKEN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
   },
   define: {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
+    'process.env.GH_TOKEN': JSON.stringify(process.env.GH_TOKEN || ''),
     '__BUILD_TIME__': JSON.stringify(new Date().toLocaleString('en-US', {
       timeZone: 'Asia/Jakarta',
       year: 'numeric',


### PR DESCRIPTION
## Summary
- resolve a GitHub API token from either build-time or runtime environments
- apply the token to all GitHub API requests to benefit from higher rate limits
- expose the GH_TOKEN build variable and extend global types for type safety

## Testing
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d9ed994ef8832fa315dbff25b839c2